### PR TITLE
Tests & support parsing

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(schemas, options) {
   return function*(next) {
     try {
       for (let key in schemas) {
-        yield (function() {
+        this.request[key] = yield (function() {
           return function(cb) {
             joi.validate(this.request[key], schemas[key], options, cb);
           };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Joi validation middleware",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "istanbul cover --root . node_modules/mocha/bin/_mocha --",
+    "posttest": "eslint ."
   },
   "repository": {
     "type": "git",
@@ -21,6 +22,13 @@
   },
   "homepage": "https://github.com/pierreinglebert/koa-joi",
   "devDependencies": {
-    "eslint": "1.10.1"
+    "eslint": "1.10.1",
+    "istanbul": "~0.4.2",
+    "joi": "7.2.0",
+    "koa": "1.1.2",
+    "koa-bodyparser": "~2.0.1",
+    "mocha": "*",
+    "should": "*",
+    "supertest": "~1.1.0"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,2 @@
+env:
+  mocha: true

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+-r should

--- a/test/spec.js
+++ b/test/spec.js
@@ -38,4 +38,21 @@ describe('koa-joi', function() {
       .end(done);
   });
 
+  it('should parse a valid request', function(done) {
+    app.use(function* () {
+      try {
+        this.request.body.test.should.be.type('number');
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+
+    request(app.listen())
+      .post('/')
+      .send({ test: '1' })
+      .expect(404)
+      .end(Function.prototype);
+  });
+
 });

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var request = require('supertest'),
+  koa = require('koa'),
+  bodyParser = require('koa-bodyparser'),
+  joi = require('joi'),
+  validate = require('..');
+
+describe('koa-joi', function() {
+
+  var app;
+
+  beforeEach(function() {
+    app = koa();
+
+    app.use(bodyParser());
+    app.use(validate({
+      body: {
+        test: joi.number().required()
+      }
+    }));
+
+  });
+
+  it('should reject an invalid request', function(done) {
+    request(app.listen())
+      .post('/')
+      .send({ fail: 'fail' })
+      .expect(400)
+      .end(done);
+  });
+
+  it('should accept a valid request', function(done) {
+    request(app.listen())
+      .post('/')
+      .send({ test: 1 })
+      .expect(404)
+      .end(done);
+  });
+
+});


### PR DESCRIPTION
By default `joi` parses values (you can turn this off with options), but as it stands those values are basically ignored. This fixes that!

I also added testing/tests, it's at 100% coverage.
