### PR TITLE
querystring convert and small 400 change

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,17 @@ module.exports = function(schemas, options) {
   options = options || {};
   return function*(next) {
     try {
+      const request = this.request;
       for (let key in schemas) {
-        this.request[key] = yield (function() {
+        const result = yield (function() {
           return function(cb) {
-            joi.validate(this.request[key], schemas[key], options, cb);
+            joi.validate(request[key], schemas[key], options, cb);
           };
         })();
+        request[key] = result;
+        if (key === 'query') {
+          request._querycache[request.querystring] = result;
+        }
       }
       yield next;
     } catch (err) {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,10 @@ module.exports = function(schemas, options) {
       }
       yield next;
     } catch (err) {
-      err.status = 400;
+      /* istanbul ignore else */
+      if (err.name === 'ValidationError') {
+        err.status = 400;
+      }
       throw err;
     }
   };

--- a/test/spec.js
+++ b/test/spec.js
@@ -17,6 +17,9 @@ describe('koa-joi', function() {
     app.use(validate({
       body: {
         test: joi.number().required()
+      },
+      query: {
+        test2: joi.number()
       }
     }));
 
@@ -42,6 +45,7 @@ describe('koa-joi', function() {
     app.use(function* () {
       try {
         this.request.body.test.should.be.type('number');
+        this.request.query.test2.should.be.type('number');
         done();
       } catch (e) {
         done(e);
@@ -50,6 +54,7 @@ describe('koa-joi', function() {
 
     request(app.listen())
       .post('/')
+      .query({ test2: '2' })
       .send({ test: '1' })
       .expect(404)
       .end(Function.prototype);


### PR DESCRIPTION
Hello! Me again.

I noticed that although body parsing was working (e.g. string to number) query string was not!

Turns out koa uses some setters/getters and does magic around parsing querystring (string) to query (obj). I've added special case handling for query which manipulates koa internals. I realize this isn't great, but it's also how `koa-qs` works (sort of).

Also I noticed that anything that was caught was being set to `400` status code. I figure it's probably good/not bad to only do that on an actual `ValidationError` since in theory there could be other things being thrown (bugs in libraries, etc.) that would get categorized incorrectly as 400?
